### PR TITLE
Make command optional

### DIFF
--- a/urlview.py
+++ b/urlview.py
@@ -32,8 +32,12 @@ def urlview(data, buf, args):
         weechat.prnt(buf, "No URLs found")
         return weechat.WEECHAT_RC_OK
 
+    if not weechat.config_is_set_plugin("command"):
+        weechat.config_set_plugin("command", "urlview")
+    command = weechat.config_get_plugin("command")
+
     text = "\n".join(reversed(lines))
-    response = os.system("echo %s | urlview" % pipes.quote(text))
+    response = os.system("echo %s | %s" % (pipes.quote(text), command))
     if response != 0:
         weechat.prnt(buf, "No URLs found")
 


### PR DESCRIPTION
In cases where there is a clear context, such as mail and chat, I prefer to use `urlscan` instead of `urlview`. I've been using your plugin with `urlscan` now for some time, and it works really well. As there are probably some more people around who might prefer another, similar, program, I've added a config option for the command the URLs are sent to, defaulting to `urlview`.
