### PR TITLE
urlscan usage updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,10 @@ wget https://raw.githubusercontent.com/keith/urlview-weechat/master/urlview.py ~
 cd ~/.weechat/python/autoload && ln -s ../urlview.py .
 ```
 
+## Configuration
+
+By default this script uses urlview to handle urls. To use urlscan, you can
+set `plugins.var.python.urlview.command` to "urlscan".
+
 This is a python rewrite of [this ruby
 plugin](https://weechat.org/files/scripts/unofficial/urlview.rb)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # urlview-weechat
 
 This is a simple [weechat](https://weechat.org/) plugin that allows you
-to pipe buffers through [urlview](https://github.com/sigpipe/urlview).
+to pipe buffers through [urlview](https://github.com/sigpipe/urlview) or
+[urlscan](https://github.com/firecat53/urlscan).
 This gives you an interactive list of URLs to open, which is especially
 helpful if there are multiple URLs in the buffer making
 [urlgrab](https://weechat.org/scripts/source/urlgrab.py.html/) hard to
@@ -9,11 +10,15 @@ use.
 
 ## Installation
 
-Copy the script to `~/.weechat/python/autoload`
+Copy the script to `~/.weechat/python/`
+
+If you want it to be loaded when you start weechat, you must then link to it
+from `~/.weechat/python/autoload/`
 
 ```sh
 mkdir -p ~/.weechat/python/autoload
-wget https://raw.githubusercontent.com/keith/urlview-weechat/master/urlview.py ~/.weechat/python/autoload
+wget https://raw.githubusercontent.com/keith/urlview-weechat/master/urlview.py ~/.weechat/python/
+cd ~/.weechat/python/autoload && ln -s ../urlview.py .
 ```
 
 This is a python rewrite of [this ruby

--- a/urlview.py
+++ b/urlview.py
@@ -8,7 +8,7 @@
 # 12-21-2015: Version 1.0.1: reverse text passed to urlview
 # 12-22-2015: Version 1.0.2: remove weechat color from messages
 # 10-23-2016: Version 1.0.3: allows setting urlscan or urlview to handle urls
-# 02-14-2029: Version 1.0.4: fixes buffer issues when using urlscan
+# 02-14-2020: Version 1.0.4: fixes buffer issues when using urlscan
 
 
 import distutils.spawn

--- a/urlview.py
+++ b/urlview.py
@@ -36,7 +36,17 @@ def urlview(data, buf, args):
         weechat.config_set_plugin("command", "urlview")
     command = weechat.config_get_plugin("command")
 
-    text = "\n".join(reversed(lines))
+    if command == 'urlscan':
+        # urlscan doesn't parse the first line of text that is piped to it; to
+        # ensure that we don't miss a url we pad with a newline.
+        lines.insert(0, '\n')
+        text = "\n".join(lines)
+    else:
+        # Reverse lines when using urlview; w/o the context that urlscan
+        # provides, it's easier to find the correct url if the most recent one
+        # in chat is the one that's at the top of the list.
+        text = "\n".join(reversed(lines))
+
     response = os.system("echo %s | %s" % (pipes.quote(text), command))
     if response != 0:
         weechat.prnt(buf, "No URLs found")

--- a/urlview.py
+++ b/urlview.py
@@ -9,6 +9,7 @@
 # Version 1.0.1: reverse text passed to urlview
 # Version 1.0.2: remove weechat color from messages
 
+
 import distutils.spawn
 import os
 import pipes
@@ -57,15 +58,19 @@ def urlview(data, buf, args):
 
 
 def main():
+
     if distutils.spawn.find_executable("urlview") is None:
         return weechat.WEECHAT_RC_ERROR
 
     if not weechat.register("urlview", "Keith Smiley", "1.0.2", "MIT",
-                            "Use urlview on the current buffer", "", ""):
+                            "Use urlview or urlscan on the current buffer",
+                            "", ""):
         return weechat.WEECHAT_RC_ERROR
 
-    weechat.hook_command("urlview", "Pass the current buffer to urlview", "",
+    weechat.hook_command("urlview",
+                         "Pass the current buffer to urlview or urlscan", "",
                          "", "", "urlview", "")
+
 
 if __name__ == "__main__":
     main()

--- a/urlview.py
+++ b/urlview.py
@@ -37,6 +37,10 @@ def urlview(data, buf, args):
         weechat.config_set_plugin("command", "urlview")
     command = weechat.config_get_plugin("command")
 
+    if distutils.spawn.find_executable(command) is None:
+        weechat.prnt(buf, "%s is not installed" % command)
+        return weechat.WEECHAT_RC_ERROR
+
     if command == 'urlscan':
         # urlscan doesn't parse the first line of text that is piped to it; to
         # ensure that we don't miss a url we pad with a newline.
@@ -58,10 +62,6 @@ def urlview(data, buf, args):
 
 
 def main():
-
-    if distutils.spawn.find_executable("urlview") is None:
-        return weechat.WEECHAT_RC_ERROR
-
     if not weechat.register("urlview", "Keith Smiley", "1.0.2", "MIT",
                             "Use urlview or urlscan on the current buffer",
                             "", ""):

--- a/urlview.py
+++ b/urlview.py
@@ -4,10 +4,11 @@
 # /urlview
 #
 # History:
-# 10-04-2015
-# Version 1.0.0: initial release
-# Version 1.0.1: reverse text passed to urlview
-# Version 1.0.2: remove weechat color from messages
+# 10-04-2015: Version 1.0.0: initial release
+# 12-21-2015: Version 1.0.1: reverse text passed to urlview
+# 12-22-2015: Version 1.0.2: remove weechat color from messages
+# 10-23-2016: Version 1.0.3: allows setting urlscan or urlview to handle urls
+# 02-14-2029: Version 1.0.4: fixes buffer issues when using urlscan
 
 
 import distutils.spawn


### PR DESCRIPTION
* Changes buffer handling when using urlscan so that urls are not lost and the
  context around the url makes sense.
* Fixes the check for installed binary so weechat can still register the plugin.
* Updates docs.